### PR TITLE
use local config.json for user specific values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 
 .env
+/config.json

--- a/bot.js
+++ b/bot.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const config = require("./config.json")
 
 const tmi = require('tmi.js');
 
@@ -34,27 +35,12 @@ function onMessageHandler(target, context, msg, self) {
 
   // Remove whitespace from chat message
   const commandName = msg.trim();
-  const kaeId = 513203757;
+  const botTwitchId = config.twitch_id;
   const commandUserId = context['user-id'];
 
-  const mods = [
-    'mtniss',
-    'communicans',
-    'jennyouch',
-    'ludicrouslyliam',
-    'shaynigami',
-    'robindesu',
-    'fuchs_',
-    'totallynotatwork64',
-    'virtrand',
-    'infinitynier',
-    'ludicrouslyluc',
-    'justether',
-    'griffuuu',
-    'inomicecream',
-  ];
+  const mods = config.mods
 
-  const userMatch = ['kae_tv', 'kae', 'kaelyn'];
+  const userMatch = config.targets
 
   if (commandName.match(/!d(\d+)/)) {
     // dice
@@ -63,7 +49,7 @@ function onMessageHandler(target, context, msg, self) {
     let sides = result[1];
     const num = rollDice(sides);
     client.say(target, `You rolled a ${num}.`);
-  } else if (commandUserId == kaeId && msg.match(/(\d+)% peepoShy/)) {
+  } else if (commandUserId == botTwitchId && msg.match(/(\d+)% peepoShy/)) {
     // ban bot
     let re = /(.*), your love compatibility with (.*) is like a (\d+)% peepoShy/;
     let result = msg.match(re);
@@ -71,7 +57,7 @@ function onMessageHandler(target, context, msg, self) {
     let user = result[2]; // kae_tv
     let pct = result[3]; // 73
 
-    if (result && userMatch.includes(user) && pct < 50) {
+    if (result && userMatch.includes(user) && pct < config.thresholds['love_command']) {
       client.say(target, `/ban ${sender}`);
 
       setTimeout(async () => {
@@ -79,7 +65,7 @@ function onMessageHandler(target, context, msg, self) {
         if (mods.includes(sender)) {
           client.say(target, `/mod ${sender}`);
         }
-      }, 2000);
+      }, (1000 * config.timers.unban_timeout) ); // 1000 * seconds = milliseconds
     }
   }
 }

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,0 +1,34 @@
+{
+    "twitch_id": 513203757,
+
+    "mods": [
+        "mtniss",
+        "communicans",
+        "jennyouch",
+        "ludicrouslyliam",
+        "shaynigami",
+        "robindesu",
+        "fuchs_",
+        "totallynotatwork64",
+        "virtrand",
+        "infinitynier",
+        "ludicrouslyluc",
+        "justether",
+        "griffuuu",
+        "inomicecream"
+    ],
+
+    "targets": [
+        "kae_tv", 
+        "kae", 
+        "kaelyn"
+    ],
+
+    "thresholds": {
+        "love_command": 50
+    },
+
+    "timers": {
+        "unban_timeout": 2
+    }
+}


### PR DESCRIPTION
moved the following values for vars into an external `config.json` file:

- `twitch_id`: the twitch id of the bot account
- `mods`: an array of usernames (sender) who will be added as a mod after ban/unban
- `targets`: an array of usernames (targets) who will trigger the ban command
- `thresholds`: keys and values for certain thresholds ➡ example: only ban if love command result is less than 50%
- `timers`: keys and values for certain timeouts  ➡ example: unban (and mod) after 2 seconds

provided a `config-sample.json` as a starting template. rename `config-sample.json` to `config.json` after first time setup

added `config.json` to `.gitignore`, so user specific values (usernames, ids) will not be part of the repository